### PR TITLE
Initial PSK binding proposal.

### DIFF
--- a/draft-ietf-tls-esni.md
+++ b/draft-ietf-tls-esni.md
@@ -499,18 +499,13 @@ computed from Z as follows:
 ~~~~
    Zx = HKDF-Extract(0, Z)
    nonce = HKDF-Expand-Label(Zx, "esni nonce", Hash(ESNIContents), 32)
-   key = HKDF-Expand-Label(Zx, KeyLabel, Hash(ESNIContents), key_length)
-   iv = HKDF-Expand-Label(Zx, IVLabel, Hash(ESNIContents), iv_length)
+   key = HKDF-Expand-Label(Zx, "esni key", Hash(ESNIContents), key_length)
+   iv = HKDF-Expand-Label(Zx, "esni iv", Hash(ESNIContents), iv_length)
 ~~~~
 
 where ESNIContents is as specified below and Hash is the hash function
 associated with the HKDF instantiation. The salt argument for HKDF-Extract is a
-string consisting of Hash.length bytes set to zeros. For a client's first
-ClientHello, KeyLabel = "esni key" and IVLabel = "esni iv", whereas for a
-client's second ClientHello, sent in response to a HelloRetryRequest,
-KeyLabel = "hrr esni key" and IVLabel = "hrr esni iv". (This label swap
-is done to prevent nonce re-use since the client's ESNI key share, and
-thus the value of Zx, does not change across ClientHello retries.)
+string consisting of Hash.length bytes set to zeros.
 
 ~~~
    struct {
@@ -734,14 +729,8 @@ calling application.
 
 If the server sends a HelloRetryRequest in response to the ClientHello
 and the client can send a second updated ClientHello per the rules in
-{{RFC8446}}, the "encrypted_server_name" extension values which do not depend
-on the (possibly updated) KeyShareClientHello, i.e,,
-ClientEncryptedSNI.suite, ClientEncryptedSNI.key_share, and
-ClientEncryptedSNI.record_digest, MUST NOT change across ClientHello messages.
-Moreover, ClientESNIInner MUST not change across ClientHello messages.
-Informally, the values of all unencrypted extension information, as well as
-the inner extension plaintext, must be consistent between the first and
-second ClientHello messages.
+{{RFC8446}}, the "encrypted_server_name" extension MUST NOT change across
+ClientHello messages.
 
 ### Authenticating for the public name {#auth-public-name}
 
@@ -887,10 +876,9 @@ the latter case, it does not make any changes to the TLS
 messages, but just blindly forwards them.
 
 If the ClientHello is the result of a HelloRetryRequest, servers MUST
-abort the connection with an "illegal_parameter" alert if any of the
-ClientEncryptedSNI.suite, ClientEncryptedSNI.key_share, ClientEncryptedSNI.record_digest,
-or decrypted ClientESNIInner values from the second ClientHello do not
-match that of the first ClientHello.
+abort the connection with an "illegal_parameter" alert if any part of the
+"encrypted_server_name" extension does not match that of the first ClientHello.
+The servers MUST check the corresponding binder value of the second ClientHello.
 
 ## Shared Mode Server Behavior
 

--- a/draft-ietf-tls-esni.md
+++ b/draft-ietf-tls-esni.md
@@ -554,13 +554,8 @@ The ClientEncryptedSNI.encrypted_sni value is then computed using the usual
 TLS 1.3 AEAD:
 
 ~~~~
-    encrypted_sni = AEAD-Encrypt(key, iv, KeyShareClientHello, ClientESNIInner)
+    encrypted_sni = AEAD-Encrypt(key, iv, "", ClientESNIInner)
 ~~~~
-
-Where KeyShareClientHello is the "extension_data" field of the "key_share"
-extension in a Client Hello (Section 4.2.8 of {{!RFC8446}})). Including
-KeyShareClientHello in the AAD of AEAD-Encrypt binds the ClientEncryptedSNI
-value to the ClientHello and prevents cut-and-paste attacks.
 
 Note: future extensions may end up reusing the server's ESNIKeyShareEntry
 for other purposes within the same message (e.g., encrypting other
@@ -879,8 +874,10 @@ the "server_name" extension. Any actual "server_name" extension is
 ignored, which also means the server MUST NOT send the "server_name"
 extension to the client.
 
-The server MUST then validate the corresponding binder value (see {{client-hello-binding}}).
-If this value is not present or does not validate, the server MUST abort the handshake.
+The server MUST then validate the corresponding binder value (see 
+{{client-hello-binding}}). If this value is not present or does not validate, the
+server MUST ignore the extension and proceed with the connection, as if the
+ClientEncryptedSNI did not match any known ESNIKeys structures.
 
 Upon determining the true SNI, the client-facing server then either
 serves the connection directly (if in Shared Mode), in which case

--- a/draft-ietf-tls-esni.md
+++ b/draft-ietf-tls-esni.md
@@ -853,6 +853,11 @@ case.
 If the ClientEncryptedSNI value does match a known ESNIKeys, the server
 performs the following checks:
 
+- The server MUST validate the corresponding binder value (see {{client-hello-binding}}).
+  If this value is not present or does not validate, the server MUST ignore the extension
+  and proceed with the connection, as if the ClientEncryptedSNI did not match any known
+  ESNIKeys structures.
+
 - If the ClientEncryptedSNI.key_share group does not match one in the ESNIKeys.keys,
   it MUST abort the connection with an "illegal_parameter" alert.
 
@@ -873,11 +878,6 @@ server uses the PaddedServerNameList.sni value as if it were
 the "server_name" extension. Any actual "server_name" extension is
 ignored, which also means the server MUST NOT send the "server_name"
 extension to the client.
-
-The server MUST then validate the corresponding binder value (see 
-{{client-hello-binding}}). If this value is not present or does not validate, the
-server MUST ignore the extension and proceed with the connection, as if the
-ClientEncryptedSNI did not match any known ESNIKeys structures.
 
 Upon determining the true SNI, the client-facing server then either
 serves the connection directly (if in Shared Mode), in which case


### PR DESCRIPTION
This adds the PSK binding via a custom PSK identity associated with extensions. Maybe a more general version would be useful to stick somewhere so that any extension which wants to do a binding doesn't need to hack it in?

Additional changes:
- Remove label swapping, since the PSK ClientHello binding should be sufficient to prevent reuse.
- Remove the AAD of KeyShareClientHello since the PSK ClientHello binding should be sufficient.
- Since now the encrypted_sni extension doesn't change at all as a result of HRR, simplify the wording to make sure the whole extension doesn't change. (server might not actually need to check if doesn't change, it just needs to be consistent in the processing of the extension, ignoring CH1 entirely, but saying it checks it doesn't change seems simplest.)

The naming/formatting of the Client Hello Binding section probably could use some work, not sure how to indicate that this is a hack onto an existing extension. (There was a nicer structure where there was a single PSK identity for extensions, and then we had a struct embedded in the PskBinderEntry, but it looks like the max PskBinderEntry size is 255 bytes, which is kind of limiting, though maybe doable if we think no more than 7 extensions will play these binding games.)